### PR TITLE
Silence unused variable warnings caused by BT_ASSERT() in non-debug mode

### DIFF
--- a/include/babeltrace/assert-internal.h
+++ b/include/babeltrace/assert-internal.h
@@ -39,7 +39,17 @@
  */
 # define BT_ASSERT_FUNC
 #else
-# define BT_ASSERT(_cond)
+/*
+ * When BT_DEBUG_MODE is not defined, define BT_ASSERT() macro to the following
+ * to trick the compiler into thinking that the variable passed as condition to
+ * the assertion is used. This is to prevent set-but-not-used warnings from the
+ * compiler when assertions are disabled. The `sizeof` operator also makes sure
+ * that the `_cond` expression is not evaluated, thus preventing unwanted side
+ * effects.
+ *
+ * In-depth explanation: https://stackoverflow.com/questions/37411809/how-to-elegantly-fix-this-unused-variable-warning/37412551#37412551
+ */
+# define BT_ASSERT(_cond)	((void) sizeof((void) (_cond), 0))
 # define BT_ASSERT_FUNC		__attribute__((unused))
 #endif /* BT_DEBUG_MODE */
 


### PR DESCRIPTION
When building with the BABELTRACE_DEBUG_MODE configure option _not_ set,
multiple set-but-not-used warnings are emitted by the compiler. Most of
the time this happens because BT_ASSERT() is used to verify the return
value of functions and when not in DEBUG_MODE those return value are not
used.

The solution is to explicitly tell the compiler that we don't care about
this value so that it does not emit warning when building in
non-DEBUG_MODE. This approach also makes sure not to evaluate the
expression using the `sizeof` operator.

See this post for further details [1].

[1]: https://stackoverflow.com/questions/37411809/how-to-elegantly-fix-this-unused-variable-warning/37412551#37412551

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>