### PR TITLE
Bypass distutils changed file check

### DIFF
--- a/bindings/python/bt2/Makefile.am
+++ b/bindings/python/bt2/Makefile.am
@@ -80,8 +80,8 @@ copy-static-deps.stamp: $(STATIC_BINDINGS_DEPS)
 	touch $@
 
 build-python-bindings.stamp: copy-static-deps.stamp $(GENERATED_BINDINGS_DEPS)
-	$(BUILD_FLAGS) $(PYTHON) $(builddir)/setup.py build_ext --swig "$(SWIG)"
-	$(BUILD_FLAGS) $(PYTHON) $(builddir)/setup.py build
+	$(BUILD_FLAGS) $(PYTHON) $(builddir)/setup.py build_ext --force --swig "$(SWIG)"
+	$(BUILD_FLAGS) $(PYTHON) $(builddir)/setup.py build --force
 	touch $@
 
 install-exec-local: build-python-bindings.stamp


### PR DESCRIPTION
Changes made to a SWIG interface file (.i) that is included in
native_bt.i would not trigger rebuilding of the extension on `make`
as the main source file (native_bt.i) has not changed.

The Makefile is already tracking when files changed and need to be
recompiled so we can simply bypass the setup.py checks by using the
--force flag.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>