### PR TITLE
Fix: flt.utils.muxer: reset is_ended variable after each iteration

### DIFF
--- a/plugins/utils/muxer/muxer.c
+++ b/plugins/utils/muxer/muxer.c
@@ -910,13 +910,13 @@ bt_self_message_iterator_status validate_muxer_upstream_msg_iters(
 	bt_self_message_iterator_status status =
 		BT_SELF_MESSAGE_ITERATOR_STATUS_OK;
 	size_t i;
-	bool is_ended = false;
 
 	BT_LOGV("Validating muxer's upstream message iterator wrappers: "
 		"muxer-msg-iter-addr=%p", muxer_msg_iter);
 
 	for (i = 0; i < muxer_msg_iter->active_muxer_upstream_msg_iters->len;
 			i++) {
+		bool is_ended = false;
 		struct muxer_upstream_msg_iter *muxer_upstream_msg_iter =
 			g_ptr_array_index(
 				muxer_msg_iter->active_muxer_upstream_msg_iters,


### PR DESCRIPTION
Problem
-------
Whenever an upstream message iterator returns STATUS_END, we remove it
from the array used to order the messages. The variable `is_ended` is
used to record if a upstream message iterator is ended and must be
removed. This variable is only set to false _before_ the loop. If the
first upstream message iterator in the array needs to be removed, all
the following iterators will be mistakenly removed.

Solution
--------
The `is_ended` variable must be reset to false at each iteration so that
only the upstream message iterator that is actually ended is removed from
the array.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>