### PR TITLE
Generate compilation error if both BT_DEBUG_MODE and NDEBUG are defined

### DIFF
--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -89,6 +89,8 @@ babeltrace_CFLAGS =	$(AM_CFLAGS) -DBT_SET_DEFAULT_IN_TREE_CONFIGURATION
 babeltrace_log_bin_SOURCES = babeltrace-log.c
 babeltrace_log_bin_LDADD = \
 	$(top_builddir)/compat/libcompat.la \
+	$(top_builddir)/common/libbabeltrace-common.la \
+	$(top_builddir)/logging/libbabeltrace-logging.la \
 	$(POPT_LIBS)
 babeltrace_log_bin_CFLAGS = $(AM_CFLAGS) '-DBT_CLI_PATH="$(abs_top_builddir)/cli/babeltrace$(EXEEXT)"'
 

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -3,4 +3,4 @@ AM_CPPFLAGS += -DINSTALL_LIBDIR=\"$(libdir)\"
 
 noinst_LTLIBRARIES = libbabeltrace-common.la
 
-libbabeltrace_common_la_SOURCES = common.c logging.c logging.h
+libbabeltrace_common_la_SOURCES = assert.c common.c logging.c logging.h

--- a/common/assert.c
+++ b/common/assert.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 EfficiOS Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <babeltrace/assert-internal.h>
+#include <babeltrace/common-internal.h>
+
+void bt_common_assert_failed(
+	const char *file, int line, const char *func, const char *assertion) {
+	bt_common_color_bold();
+	bt_common_color_fg_red();
+	fprintf(stderr,
+		"%s%s:%d: %s: Assertion %s`%s`%s failed. （╯ ͡°  □ ͡°）╯︵ ┻━┻%s\n",
+		bt_common_color_bold(), file, line, func,
+		bt_common_color_fg_red(), assertion,
+		bt_common_color_fg_default(), bt_common_color_reset());
+	abort();
+}

--- a/include/babeltrace/assert-internal.h
+++ b/include/babeltrace/assert-internal.h
@@ -28,12 +28,22 @@
 #include <babeltrace/babeltrace-internal.h>
 
 #ifdef BT_DEBUG_MODE
+
+extern void bt_common_assert_failed(const char *file, int line,
+	const char *func, const char *assertion) __attribute__((noreturn));
+
 /*
  * Internal assertion (to detect logic errors on which the library user
  * has no influence). Use BT_ASSERT_PRE() to check a precondition which
  * must be directly or indirectly satisfied by the library user.
  */
-# define BT_ASSERT(_cond)	do { assert(_cond); } while (0)
+#define BT_ASSERT(_cond)                                                       \
+	do {                                                                   \
+		if (!(_cond)) {                                                \
+			bt_common_assert_failed(__FILE__, __LINE__, __func__,  \
+				TOSTRING(_cond));                              \
+		}                                                              \
+	} while (0)
 
 /*
  * Marks a function as being only used within a BT_ASSERT() context.

--- a/logging/log.c
+++ b/logging/log.c
@@ -7,6 +7,7 @@
 #include <babeltrace/babeltrace-internal.h>
 #include <babeltrace/common-internal.h>
 #include <pthread.h>
+#include <assert.h>
 
 #ifdef __CYGWIN__
 extern unsigned long pthread_getsequence_np(pthread_t *);

--- a/plugins/ctf/common/metadata/ctf-meta-update-in-ir.c
+++ b/plugins/ctf/common/metadata/ctf-meta-update-in-ir.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #include "ctf-meta-visitors.h"
 

--- a/tests/utils/tap/tap.c
+++ b/tests/utils/tap/tap.c
@@ -29,9 +29,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <babeltrace/assert-internal.h>
 #include <string.h>
 #include <limits.h>
+#include <assert.h>
 
 #include "tap.h"
 
@@ -304,7 +304,7 @@ diag_multiline(const char *val)
 {
 	size_t len, i, line_start_idx = 0;
 
-	BT_ASSERT(val);
+	assert(val);
 	len = strlen(val);
 
 	for (i = 0; i < len; i++) {
@@ -314,7 +314,7 @@ diag_multiline(const char *val)
 			continue;
 		}
 
-		BT_ASSERT((i - line_start_idx + 1) <= INT_MAX);
+		assert((i - line_start_idx + 1) <= INT_MAX);
 		line_length = i - line_start_idx + 1;
 		fprintf(stderr, "# %.*s", line_length, &val[line_start_idx]);
 		line_start_idx = i + 1;


### PR DESCRIPTION
Defining NDEBUG makes assert() (and therefore BT_ASSERT) inactive.  If
somebody builds with BT_DEBUG_MODE on, it's most probably because they
want to have internal Babeltrace assertions enabled.  So if NDEBUG is
defined as well, assertions will be disabled while the user thinks they
are enabled.  This can lead to the user thinking everything is fine,
while everything is actually broken.

This problem was encountered while building the Python bindings, where
the distutils native code builder was passing -DNDEBUG to the
compiler.  The BT_ASSERT macros in these files were found to be
ineffective.

This patch makes sure this doesn't happen by generating a compilation
failure if both BT_DEBUG_MODE and NDEBUG are defined.

An alternative we might want to consider is to just avoid using assert.
We could define BT_ASSERT to something that calls abort() directly if
the condition is false.

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>