### PR TITLE
Small fixes to include/

### DIFF
--- a/include/babeltrace/graph/self-component-filter.h
+++ b/include/babeltrace/graph/self-component-filter.h
@@ -54,9 +54,6 @@ bt_self_component_filter_as_component_filter(
 	return (const void *) self_comp_filter;
 }
 
-extern bt_component_filter *bt_component_filter_borrow_from_self(
-		bt_self_component_filter *self_component);
-
 extern bt_self_component_port_output *
 bt_self_component_filter_borrow_output_port_by_name(
 		bt_self_component_filter *self_component,

--- a/include/babeltrace/graph/self-component.h
+++ b/include/babeltrace/graph/self-component.h
@@ -47,10 +47,10 @@ const bt_component *bt_self_component_as_component(
 }
 
 extern void *bt_self_component_get_data(
-		const bt_self_component *private_component);
+		const bt_self_component *self_component);
 
 extern void bt_self_component_set_data(
-		bt_self_component *private_component, void *data);
+		bt_self_component *self_component, void *data);
 
 #ifdef __cplusplus
 }

--- a/include/babeltrace/types.h
+++ b/include/babeltrace/types.h
@@ -84,7 +84,6 @@ typedef struct bt_component_class_filter bt_component_class_filter;
 typedef struct bt_component_class_sink bt_component_class_sink;
 typedef struct bt_component_class_source bt_component_class_source;
 typedef struct bt_component_filter bt_component_filter;
-typedef struct bt_component_graph bt_component_graph;
 typedef struct bt_component_sink bt_component_sink;
 typedef struct bt_component_source bt_component_source;
 typedef struct bt_connection bt_connection;

--- a/lib/graph/component.c
+++ b/lib/graph/component.c
@@ -331,7 +331,7 @@ const char *bt_component_get_name(const struct bt_component *component)
 	return component->name->str;
 }
 
-struct bt_component_class *bt_component_borrow_class(
+const struct bt_component_class *bt_component_borrow_class_const(
 		const struct bt_component *component)
 {
 	BT_ASSERT_PRE_NON_NULL(component, "Component");


### PR DESCRIPTION
* Function bt_component_filter_borrow_from_self is declared, but does not
  actually exist.

* Parameters to bt_self_component_{get,set}_data are named "private",
  which is the old naming scheme.  Change that to self.

* bt_component_graph is typedef'ed to struct bt_component_graph, which
  doesn't actually exist.  struct bt_graph exists, and there's already a
  typedef for it.