### PR TITLE
plugins/ctf: Remove unused uuid-related fields in struct ctf_fs_metadata

### DIFF
--- a/plugins/ctf/fs-src/fs.h
+++ b/plugins/ctf/fs-src/fs.h
@@ -63,8 +63,6 @@ struct ctf_fs_metadata {
 	/* Owned by this */
 	char *text;
 
-	uint8_t uuid[16];
-	bool is_uuid_set;
 	int bo;
 };
 


### PR DESCRIPTION
They are unused.  The corresponding fields holding the metadata uuid are
in struct ctf_metadata_decoder, while the fields holding the trace class
uuid are in ctf_trace_class.

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>