### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,h,i}]
+indent_style = tab
+tab_width = 8
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This file helps editors set the indentation (and other whitespace)
settings correctly to match the project's coding style.

For now I have just put some simple settings for C, Swig interface and
Python files, but we can add more as needed.

See here for more details:

  https://editorconfig.org/

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>