### PR TITLE
sink.ctf.fs: Remove unused `get_field_path_elem()` function

### DIFF
--- a/plugins/ctf/fs-sink/translate-trace-ir-to-ctf-ir.c
+++ b/plugins/ctf/fs-sink/translate-trace-ir-to-ctf-ir.c
@@ -154,15 +154,6 @@ void cur_path_stack_pop(struct ctx *ctx)
 	g_array_set_size(ctx->cur_path, ctx->cur_path->len - 1);
 }
 
-static inline
-struct field_path_elem *get_field_path_elem(
-		GArray *full_field_path, uint64_t i)
-{
-	return &g_array_index(full_field_path, struct field_path_elem,
-		i);
-}
-
-
 /*
  * Creates a relative field ref (a single name) from IR field path
  * `tgt_ir_field_path`.


### PR DESCRIPTION
Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eepp/babeltrace/28)
<!-- Reviewable:end -->
