### PR TITLE
Fix: cli: Acquire reference on bt_value_null while parsing args

### DIFF
--- a/cli/babeltrace-cfg-cli-args.c
+++ b/cli/babeltrace-cfg-cli-args.c
@@ -1988,7 +1988,10 @@ struct bt_config *bt_config_query_from_args(int argc, const char *argv[],
 	int ret;
 	struct bt_config *cfg = NULL;
 	const char *leftover;
-	bt_value *params = bt_value_null;
+	bt_value *params;
+
+	params = bt_value_null;
+	bt_value_get_ref(bt_value_null);
 
 	*retcode = 0;
 	cfg = bt_config_query_create(initial_plugin_paths);


### PR DESCRIPTION
In bt_config_query_from_args, we initialize "params" to point to
bt_value_null without acquiring a reference:

    bt_value *params = bt_value_null;

when handling OPT_PARAMS, lower, we call "put" on it before assigning
params to something else:

    bt_value_put_ref(params);

This causes bt_value_null's refcount to drop to 0 and its release to be
called (which should never happen, since its refcount is initialized to
1).  This warning is shown:

    $ ./cli/babeltrace query
    ...
    04-18 13:56:12.267 10081 10081 W VALUES bt_value_null_instance_release_func@value.c:73 Releasing the null value singleton: addr=0x7f882eaf1b60

Fix it by acquiring a new reference in the beginning.

Fixes #513

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eepp/babeltrace/29)
<!-- Reviewable:end -->
